### PR TITLE
Global view variables

### DIFF
--- a/src/Http/Controllers/PagesController.php
+++ b/src/Http/Controllers/PagesController.php
@@ -24,6 +24,6 @@ class PagesController
 
         event(new PageFound($request));
 
-        return Pages::view($page);
+        return Pages::render($page);
     }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -7,9 +7,11 @@ use Symfony\Component\Finder\Finder;
 
 class Manager
 {
-    public function view(string $page)
+    private $variables = [];
+
+    public function render(string $page)
     {
-        return view()->make($page);
+        return view()->make($page, $this->getVariables());
     }
 
     public function url(string $page): string
@@ -72,11 +74,23 @@ class Manager
         return collect(
             Finder::create()
                 ->files()
-                ->name(['*.blade.php'])
+                ->name(['*.blade.php', '*.html'])
                 ->in($this->path())
                 ->sortByName()
         )->map(fn($file) => $file->getRelativePathname())
             ->values()
             ->toArray();
+    }
+
+    public function setVariable($key, $value = null): void
+    {
+        $variables = is_array($key) ? $key : [$key => $value];
+
+        $this->variables = array_merge($this->variables, $variables);
+    }
+
+    public function getVariables(): array
+    {
+        return $this->variables;
     }
 }

--- a/src/PagesServiceProvider.php
+++ b/src/PagesServiceProvider.php
@@ -20,7 +20,7 @@ class PagesServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/pages.php', 'pages');
-        $this->app->bind('pages', fn() => new Manager);
+        $this->app->singleton('pages', fn() => new Manager);
     }
 
     private function publish()

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -43,4 +43,22 @@ class ManagerTest extends TestCase
             (new Manager)->url('test.page.multi')
         );
     }
+
+    /** @test */
+    public function stores_and_retrieves_variables(): void
+    {
+        $manager = new Manager;
+
+        $manager->setVariable('single', 'value');
+        $manager->setVariable([
+            'foo' => 'bar',
+            'baz' => 'qwex',
+        ]);
+
+        $this->assertEquals([
+            'single' => 'value',
+            'foo' => 'bar',
+            'baz' => 'qwex'
+        ], $manager->getVariables());
+    }
 }

--- a/tests/PagesControllerTest.php
+++ b/tests/PagesControllerTest.php
@@ -2,11 +2,11 @@
 
 namespace Ryancco\Pages\Tests;
 
-use Illuminate\Support\Facades\Config;
 use Ryancco\Pages\Events\IncomingPageRequest;
 use Ryancco\Pages\Events\PageFound;
 use Ryancco\Pages\Events\PageNotFound;
 use Ryancco\Pages\Http\Controllers\PagesController;
+use Ryancco\Pages\Pages;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class PagesControllerTest extends TestCase
@@ -85,5 +85,22 @@ class PagesControllerTest extends TestCase
             ->getByAction(PagesController::class)
             ->gatherMiddleware()
         );
+    }
+
+    /** @test */
+    public function passes_stored_variables_to_the_view(): void
+    {
+        Pages::setVariable('single', 'value');
+        Pages::setVariable([
+            'foo' => 'bar',
+            'baz' => 'qwex',
+        ]);
+
+        $this->get('testing/test')
+            ->assertViewHas([
+                'single' => 'value',
+                'foo' => 'bar',
+                'baz' => 'qwex'
+            ]);
     }
 }


### PR DESCRIPTION
Global variables can be registered with the provided Pages facade at runtime and passed to any subsequent page views.